### PR TITLE
Fully migrate all exercises to ounit2

### DIFF
--- a/tests/example-all-fail/dune
+++ b/tests/example-all-fail/dune
@@ -1,6 +1,6 @@
 (executable
  (name test)
- (libraries base oUnit))
+ (libraries base ounit2))
 
 (alias
   (name    runtest)

--- a/tests/example-empty-file/dune
+++ b/tests/example-empty-file/dune
@@ -1,6 +1,6 @@
 (executable
  (name test)
- (libraries base oUnit))
+ (libraries base ounit2))
 
 (alias
   (name    runtest)

--- a/tests/example-ounit/Makefile
+++ b/tests/example-ounit/Makefile
@@ -1,0 +1,9 @@
+default: clean test
+
+test: 
+	dune runtest
+
+clean:
+	dune clean
+
+.PHONY: clean

--- a/tests/example-ounit/dune
+++ b/tests/example-ounit/dune
@@ -1,0 +1,16 @@
+(executable
+ (name test)
+ (libraries base oUnit))
+
+(alias
+  (name    runtest)
+  (deps    (:x test.exe))
+  (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/tests/example-ounit/dune-project
+++ b/tests/example-ounit/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.1)
+(version 1.5.1)

--- a/tests/example-ounit/expected_results.json
+++ b/tests/example-ounit/expected_results.json
@@ -1,0 +1,21 @@
+{
+  "version": 2,
+  "status": "fail",
+  "message": null,
+  "tests": [
+    {
+      "name": "leap tests:0:leap year",
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": null
+    },
+    {
+      "name": "leap tests:1:not leap year",
+      "status": "fail",
+      "message": "expected: false but got: true\nRaised at OUnitAssert.assert_failure in file \"src/lib/ounit2/advanced/oUnitAssert.ml\", line 45, characters 2-27\nCalled from OUnitRunner.run_one_test.(fun) in file \"src/lib/ounit2/advanced/oUnitRunner.ml\", line 83, characters 13-26",
+      "output": null,
+      "test_code": null
+    }
+  ]
+}

--- a/tests/example-ounit/leap.ml
+++ b/tests/example-ounit/leap.ml
@@ -1,0 +1,2 @@
+let leap_year year =
+  year <> 1996

--- a/tests/example-ounit/leap.mli
+++ b/tests/example-ounit/leap.mli
@@ -1,0 +1,1 @@
+val leap_year: int -> bool

--- a/tests/example-ounit/test.ml
+++ b/tests/example-ounit/test.ml
@@ -1,0 +1,15 @@
+(* leap - 1.5.1 *)
+open OUnit2
+open Leap
+
+let ae exp got _test_ctxt = assert_equal exp got ~printer:string_of_bool
+
+let tests = [
+  "leap year" >::
+  ae false (leap_year 1996);
+  "not leap year" >::
+  ae false (leap_year 1997);
+]
+
+let () =
+  run_test_tt_main ("leap tests" >::: tests)

--- a/tests/example-partial-fail/dune
+++ b/tests/example-partial-fail/dune
@@ -1,6 +1,6 @@
 (executable
  (name test)
- (libraries base oUnit))
+ (libraries base ounit2))
 
 (alias
   (name    runtest)

--- a/tests/example-single-test/Makefile
+++ b/tests/example-single-test/Makefile
@@ -1,0 +1,9 @@
+default: clean test
+
+test: 
+	dune runtest
+
+clean:
+	dune clean
+
+.PHONY: clean

--- a/tests/example-single-test/dune
+++ b/tests/example-single-test/dune
@@ -1,0 +1,7 @@
+(test
+ (name test)
+ (libraries base ounit2))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/tests/example-single-test/dune-project
+++ b/tests/example-single-test/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.1)
+(version 1.1.0)

--- a/tests/example-single-test/expected_results.json
+++ b/tests/example-single-test/expected_results.json
@@ -1,0 +1,14 @@
+{
+  "version": 2,
+  "status": "pass",
+  "message": null,
+  "tests": [
+    {
+      "name": "Hello World tests:0:Say Hi!",
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": null
+    }
+  ]
+}

--- a/tests/example-single-test/hello_world.ml
+++ b/tests/example-single-test/hello_world.ml
@@ -1,0 +1,1 @@
+let hello = "Hello, World!"

--- a/tests/example-single-test/hello_world.mli
+++ b/tests/example-single-test/hello_world.mli
@@ -1,0 +1,4 @@
+(*
+   Returns "Hello, World!"
+*)
+val hello: string

--- a/tests/example-single-test/test.ml
+++ b/tests/example-single-test/test.ml
@@ -1,0 +1,12 @@
+(* hello-world - 1.1.0 *)
+open OUnit2
+open Hello_world
+
+let ae exp got _test_ctxt = assert_equal ~printer:(fun x -> x) exp got
+
+let tests = [
+  "Say Hi!" >:: ae "Hello, World!" hello;
+]
+
+let () =
+  run_test_tt_main ("Hello World tests" >::: tests)

--- a/tests/example-success/dune
+++ b/tests/example-success/dune
@@ -1,6 +1,6 @@
 (executable
  (name test)
- (libraries base oUnit))
+ (libraries base ounit2))
 
 (alias
   (name    runtest)

--- a/tests/example-syntax-error/dune
+++ b/tests/example-syntax-error/dune
@@ -1,6 +1,6 @@
 (executable
  (name test)
- (libraries base oUnit))
+ (libraries base ounit2))
 
 (alias
   (name    runtest)


### PR DESCRIPTION
The ocaml-test-runner repo should be tested with `ounit2` and not `oUnit`

Relates to https://github.com/exercism/ocaml/pull/458, 