### PR TITLE
Add deriving opam packages back

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM ocaml/opam:alpine-3.18-ocaml-5.2 AS runner
 ENV PATH="/home/opam/.opam/5.2/bin:${PATH}"
 
 RUN opam update
-RUN opam install base ounit2 qcheck react calendar
+RUN opam install base ounit2 ppx_deriving ppx_sexp_conv qcheck react calendar
 
 WORKDIR /opt/test-runner
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ocaml/opam:alpine-3.18-ocaml-5.2 AS builder
+FROM ocaml/opam:alpine-3.18-ocaml-5.1 AS builder
 
-ENV PATH="/home/opam/.opam/5.2/bin:${PATH}"
+ENV PATH="/home/opam/.opam/5.1/bin:${PATH}"
 
 # We purposefully don't combine the opam update and opam install steps
 # to allow the opam update layer to be re-used in the runner image below 
@@ -11,12 +11,12 @@ WORKDIR /opt/test-runner
 COPY runner/ .
 RUN dune build
 
-FROM ocaml/opam:alpine-3.18-ocaml-5.2 AS runner
+FROM ocaml/opam:alpine-3.18-ocaml-5.1 AS runner
 
-ENV PATH="/home/opam/.opam/5.2/bin:${PATH}"
+ENV PATH="/home/opam/.opam/5.1/bin:${PATH}"
 
 RUN opam update
-RUN opam install base ounit2 ppx_deriving ppx_sexp_conv qcheck react calendar
+RUN opam install base dune ounit2 ppx_deriving ppx_sexp_conv qcheck react calendar
 
 WORKDIR /opt/test-runner
 

--- a/tests/example-empty-file/expected_results.json
+++ b/tests/example-empty-file/expected_results.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
   "status": "error",
-  "message": "File \"leap.ml\", line 1:\nError: The implementation \"leap.ml\" does not match the interface \"leap.ml\": \n       The value \"leap_year\" is required but not provided\n       File \"leap.mli\", line 1, characters 0-26: Expected declaration\nmake: *** [Makefile:4: test] Error 1",
+  "message": "File \"leap.ml\", line 1:\nError: The implementation leap.ml\n       does not match the interface .test.eobjs/byte/leap.cmi: \n       The value `leap_year' is required but not provided\n       File \"leap.mli\", line 1, characters 0-26: Expected declaration\nmake: *** [Makefile:4: test] Error 1",
   "tests": null
 }


### PR DESCRIPTION
These packages got dropped in #50, but are needed by tests see https://github.com/exercism/ocaml/issues/496