### PR TITLE
Fill task id by matching test names against a regexp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ ENV PATH="/home/opam/.opam/5.1/bin:${PATH}"
 # We purposefully don't combine the opam update and opam install steps
 # to allow the opam update layer to be re-used in the runner image below 
 RUN opam update
-RUN opam install dune yojson ezxmlm
+RUN opam install dune ounit2 yojson ezxmlm
 
 WORKDIR /opt/test-runner
 COPY runner/ .
-RUN dune build
+RUN dune test && dune build
 
 FROM ocaml/opam:alpine-3.18-ocaml-5.1 AS runner
 

--- a/runner/src/case.ml
+++ b/runner/src/case.ml
@@ -1,0 +1,12 @@
+type case = { name: string; task_id: int option; failmsg: string option }
+type suite = { _tests: int; failures: int; errors: int; cases: case list }
+
+let name_task_regexp = Str.regexp {|^\(.*\)\b @ task \([1-9]+\)$|}
+
+let case_of_name raw_name failmsg =
+  if Str.string_match name_task_regexp raw_name 0 then
+    let group i = Str.matched_group i raw_name in
+    let name = group 1
+    and task_id = group 2 |> int_of_string_opt
+    in { name; task_id; failmsg }
+  else {name = raw_name; task_id = None; failmsg }

--- a/runner/src/dune
+++ b/runner/src/dune
@@ -1,5 +1,15 @@
-(executable 
+(executable
+ (modules runner)
  (public_name runner)
  (name runner)
- (libraries yojson ezxmlm unix str))
- 
+ (libraries case yojson ezxmlm unix))
+
+(library
+ (modules case)
+ (name case)
+ (libraries str))
+
+(test
+ (modules test)
+ (name test)
+ (libraries case ounit2))

--- a/runner/src/dune
+++ b/runner/src/dune
@@ -1,5 +1,5 @@
 (executable 
  (public_name runner)
  (name runner)
- (libraries yojson ezxmlm unix))
+ (libraries yojson ezxmlm unix str))
  

--- a/runner/src/runner.ml
+++ b/runner/src/runner.ml
@@ -34,10 +34,9 @@ let check_case_failure case =
 
 let read_case case_with_attrs = 
   let attrs = fst case_with_attrs in
-  let name = get_attr "name" attrs in
-  match check_case_failure (snd case_with_attrs) with
-  | None -> { name; failmsg = None }
-  | Some m -> { name; failmsg = Some m }
+  let name = get_attr "name" attrs
+  and failmsg = check_case_failure (snd case_with_attrs) in
+  { name; failmsg }
 
 let read_xml_from_channel ch = 
   let (_, xml) = from_channel ch in 

--- a/runner/src/runner.ml
+++ b/runner/src/runner.ml
@@ -1,3 +1,4 @@
+open Case
 open Ezxmlm
 
 let version = 3
@@ -25,19 +26,6 @@ let add_to_current_env var value =
   let env = Unix.environment () in 
   let new_var = Printf.sprintf "%s=%s" var value in 
   Array.append env [| new_var |] 
-
-type case = { name: string; task_id: int option; failmsg: string option } 
-type suite = { _tests: int; failures: int; errors: int; cases: case list }
-
-let name_task_regexp = Str.regexp {|^\(.*\)\b @ task \([1-9]+\)$|}
-
-let case_of_name raw_name failmsg =
-  if Str.string_match name_task_regexp raw_name 0 then
-    let group i = Str.matched_group i raw_name in
-    let name = group 1
-    and task_id = group 2 |> int_of_string_opt
-    in { name; task_id; failmsg }
-  else {name = raw_name; task_id = None; failmsg }
 
 let check_case_failure case =
   match members_with_attr "failure" case with 

--- a/runner/src/test.ml
+++ b/runner/src/test.ml
@@ -1,0 +1,30 @@
+open OUnit2
+open Case
+
+let string_of_case case =
+  let pattern = Printf.sprintf "{ name = '%s'; task_id = %s; failmsg = '%s' }"
+  and task_id_repr = case.task_id |> Option.map string_of_int |> Option.value ~default:"None"
+  and failmsg_repr = case.failmsg |> Option.value ~default:"None"
+  in pattern case.name task_id_repr failmsg_repr
+
+let ae exp got _test_ctxt = assert_equal exp got ~printer:string_of_case
+
+let tests = [
+    "Nominal example" >::
+      ae { name = "Test"; task_id = Some 1; failmsg = Some "fail" } @@ case_of_name "Test @ task 1" (Some "fail") 
+    ; "Without task" >::
+      ae { name = "Test"; task_id = None; failmsg = None } @@ case_of_name "Test" None
+    ; "With task (multiple digits id)" >::
+      ae { name = "Test"; task_id = Some 123; failmsg = None } @@ case_of_name "Test @ task 123" None
+    ; "@ task without id" >::
+      ae { name = "Test @ task"; task_id = None; failmsg = None } @@ case_of_name "Test @ task" None
+    ; "@ task with id 0" >::
+      ae { name = "Test @ task 0"; task_id = None; failmsg = None } @@ case_of_name "Test @ task 0" None
+    ; "@ task with non integer id" >::
+      ae { name = "Test @ task foo"; task_id = None; failmsg = None } @@ case_of_name "Test @ task foo" None
+    ; "@ task with no test name" >::
+      ae { name = " @ task 1"; task_id = None; failmsg = None } @@ case_of_name " @ task 1" None
+  ]
+;;
+
+let () = run_test_tt_main ("runner tests" >::: tests)

--- a/tests/example-all-fail/expected_results.json
+++ b/tests/example-all-fail/expected_results.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "status": "fail",
   "message": null,
   "tests": [
@@ -8,14 +8,16 @@
       "status": "fail",
       "message": "expected: false but got: true",
       "output": null,
-      "test_code": null
+      "test_code": null,
+      "task_id": null
     },
     {
       "name": "leap tests:1:not leap year",
       "status": "fail",
       "message": "expected: false but got: true",
       "output": null,
-      "test_code": null
+      "test_code": null,
+      "task_id": null
     }
   ]
 }

--- a/tests/example-empty-file/expected_results.json
+++ b/tests/example-empty-file/expected_results.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "status": "error",
   "message": "File \"leap.ml\", line 1:\nError: The implementation leap.ml\n       does not match the interface .test.eobjs/byte/leap.cmi: \n       The value `leap_year' is required but not provided\n       File \"leap.mli\", line 1, characters 0-26: Expected declaration\nmake: *** [Makefile:4: test] Error 1",
   "tests": null

--- a/tests/example-ounit/expected_results.json
+++ b/tests/example-ounit/expected_results.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "status": "fail",
   "message": null,
   "tests": [
@@ -8,14 +8,16 @@
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": null
+      "test_code": null,
+      "task_id": null
     },
     {
       "name": "leap tests:1:not leap year",
       "status": "fail",
       "message": "expected: false but got: true",
       "output": null,
-      "test_code": null
+      "test_code": null,
+      "task_id": null
     }
   ]
 }

--- a/tests/example-partial-fail/expected_results.json
+++ b/tests/example-partial-fail/expected_results.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "status": "fail",
   "message": null,
   "tests": [
@@ -8,14 +8,16 @@
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": null
+      "test_code": null,
+      "task_id": null
     },
     {
       "name": "leap tests:1:not leap year",
       "status": "fail",
       "message": "expected: false but got: true",
       "output": null,
-      "test_code": null
+      "test_code": null,
+      "task_id": null
     }
   ]
 }

--- a/tests/example-single-test/expected_results.json
+++ b/tests/example-single-test/expected_results.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "status": "pass",
   "message": null,
   "tests": [
@@ -8,7 +8,8 @@
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": null
+      "test_code": null,
+      "task_id": null
     }
   ]
 }

--- a/tests/example-success/expected_results.json
+++ b/tests/example-success/expected_results.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "status": "pass",
   "message": null,
   "tests": [
@@ -8,42 +8,48 @@
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": null
+      "test_code": null,
+      "task_id": null
     },
     {
       "name": "leap tests:1:year divisible by 2, not divisible by 4 in common year",
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": null
+      "test_code": null,
+      "task_id": null
     },
     {
       "name": "leap tests:2:year divisible by 4, not divisible by 100 in leap year",
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": null
+      "test_code": null,
+      "task_id": null
     },
     {
       "name": "leap tests:3:year divisible by 100, not divisible by 400 in common year",
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": null
+      "test_code": null,
+      "task_id": null
     },
     {
       "name": "leap tests:4:year divisible by 400 in leap year",
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": null
+      "test_code": null,
+      "task_id": null
     },
     {
       "name": "leap tests:5:year divisible by 200, not divisible by 400 in common year",
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": null
+      "test_code": null,
+      "task_id": null
     }
   ]
 }

--- a/tests/example-syntax-error/expected_results.json
+++ b/tests/example-syntax-error/expected_results.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "status": "error",
   "message": "File \"leap.ml\", line 1, characters 24-26:\n1 | LETTT #leap_year year @%#=\n                            ^^\nError: Syntax error\nmake: *** [Makefile:4: test] Error 1",
   "tests": null

--- a/tests/example-with-tasks/Makefile
+++ b/tests/example-with-tasks/Makefile
@@ -1,0 +1,9 @@
+default: clean test
+
+test: 
+	dune test
+
+clean:
+	dune clean
+
+.PHONY: clean

--- a/tests/example-with-tasks/dune
+++ b/tests/example-with-tasks/dune
@@ -1,0 +1,12 @@
+(library
+  (modules lucian_luscious_lasagna)
+  (name lucian_luscious_lasagna))
+
+(test
+ (modules test)
+ (name test)
+ (libraries lucian_luscious_lasagna ounit2))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/tests/example-with-tasks/dune-project
+++ b/tests/example-with-tasks/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.1)
+(version 1.5.1)

--- a/tests/example-with-tasks/expected_results.json
+++ b/tests/example-with-tasks/expected_results.json
@@ -1,0 +1,47 @@
+{
+  "version": 3,
+  "status": "pass",
+  "message": null,
+  "tests": [
+    {
+      "name": "lasagna tests:0:expected time",
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": null,
+      "task_id": 1
+    },
+    {
+      "name": "lasagna tests:1:remaining time",
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": null,
+      "task_id": 2
+    },
+    {
+      "name": "lasagna tests:2:no more time",
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": null,
+      "task_id": 2
+    },
+    {
+      "name": "lasagna tests:3:preparation time",
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": null,
+      "task_id": 3
+    },
+    {
+      "name": "lasagna tests:4:total time",
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": null,
+      "task_id": 4
+    }
+  ]
+}

--- a/tests/example-with-tasks/lucian_luscious_lasagna.ml
+++ b/tests/example-with-tasks/lucian_luscious_lasagna.ml
@@ -1,0 +1,4 @@
+let expected_time = 40
+let remaining_time already = expected_time - already
+let preparation_time layers = 2 * layers
+let total_time layers already = preparation_time layers + already

--- a/tests/example-with-tasks/test.ml
+++ b/tests/example-with-tasks/test.ml
@@ -1,0 +1,15 @@
+open OUnit2
+open Lucian_luscious_lasagna
+
+let ae exp got _test_ctxt = assert_equal exp got ~printer:string_of_int
+
+let tests =
+  [ "expected time @ task 1" >:: ae 40 expected_time
+  ; "remaining time @ task 2" >:: ae 10 @@ remaining_time 30
+  ; "no more time @ task 2" >:: ae 0 @@ remaining_time 40
+  ; "preparation time @ task 3" >:: ae 4 @@ preparation_time 2
+  ; "total time @ task 4" >:: ae 26 @@ total_time 3 20
+  ]
+;;
+
+let () = run_test_tt_main ("lasagna tests" >::: tests)


### PR DESCRIPTION
Proposal to resolve #14

- Bump version to 3 and fill task_id to null in the general case
- Match test names to check if they end by a given pattern (pattern "@ task 1" arbitrarily chosen), if there is a match use the retrieved id to fille task_id
  + Added a 'lucian lasagna' example with task ids in the golden `tests/`

Additional proposals:
- Setup unit tests for the runner code itself
  + Added unit tests for the task_id feature 