### PR TITLE
Fix: task ids with zeros would not be recognized

### DIFF
--- a/runner/src/case.ml
+++ b/runner/src/case.ml
@@ -1,7 +1,7 @@
 type case = { name: string; task_id: int option; failmsg: string option }
 type suite = { _tests: int; failures: int; errors: int; cases: case list }
 
-let name_task_regexp = Str.regexp {|^\(.*\)\b @ task \([1-9]+\)$|}
+let name_task_regexp = Str.regexp {|^\(.*\)\b @ task \([1-9][0-9]*\)$|}
 
 let case_of_name raw_name failmsg =
   if Str.string_match name_task_regexp raw_name 0 then

--- a/runner/src/test.ml
+++ b/runner/src/test.ml
@@ -15,7 +15,7 @@ let tests = [
     ; "Without task" >::
       ae { name = "Test"; task_id = None; failmsg = None } @@ case_of_name "Test" None
     ; "With task (multiple digits id)" >::
-      ae { name = "Test"; task_id = Some 123; failmsg = None } @@ case_of_name "Test @ task 123" None
+      ae { name = "Test"; task_id = Some 210; failmsg = None } @@ case_of_name "Test @ task 210" None
     ; "@ task without id" >::
       ae { name = "Test @ task"; task_id = None; failmsg = None } @@ case_of_name "Test @ task" None
     ; "@ task with id 0" >::


### PR DESCRIPTION
In response to the bug reported here: http://forum.exercism.org/t/ocaml-test-runner-v3-allow-to-link-test-to-a-task-id/13054/2 