### PR TITLE
Update OCaml test runner image to OCaml 5.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # --disable-flat-float-array. This gives a container smaller image overall
 # but disables OCaml's optimization for float arrays. Does not prevent
 # float arrays from being used.
-FROM docker.io/ocaml/opam:alpine-ocaml-5.4-no-flat-float-array AS builder
+FROM docker.io/ocaml/opam:debian-13-ocaml-5.4-no-flat-float-array AS builder
 
 ENV PATH="/home/opam/.opam/5.4/bin:${PATH}"
 
@@ -19,7 +19,7 @@ RUN chown -R opam:opam /opt/test-runner
 COPY runner/ .
 RUN dune test && dune build
 
-FROM docker.io/ocaml/opam:alpine-ocaml-5.4-no-flat-float-array AS runner
+FROM docker.io/ocaml/opam:debian-13-ocaml-5.4-no-flat-float-array AS runner
 
 ENV PATH="/home/opam/.opam/5.4/bin:${PATH}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
-FROM ocaml/opam:alpine-3.18-ocaml-5.1 AS builder
+# Using the "no flat float array" based image which is OCaml compiled with
+# --disable-flat-float-array. This gives a container smaller image overall
+# but disables OCaml's optimization for float arrays. Does not prevent
+# float arrays from being used.
+FROM docker.io/ocaml/opam:alpine-ocaml-5.4-no-flat-float-array AS builder
 
-ENV PATH="/home/opam/.opam/5.1/bin:${PATH}"
+ENV PATH="/home/opam/.opam/5.4/bin:${PATH}"
 
 # We purposefully don't combine the opam update and opam install steps
 # to allow the opam update layer to be re-used in the runner image below 
@@ -8,12 +12,16 @@ RUN opam update
 RUN opam install dune ounit2 yojson ezxmlm
 
 WORKDIR /opt/test-runner
+
+# Set owner to opam for the dune commands
+RUN chown -R opam:opam /opt/test-runner
+
 COPY runner/ .
 RUN dune test && dune build
 
-FROM ocaml/opam:alpine-3.18-ocaml-5.1 AS runner
+FROM docker.io/ocaml/opam:alpine-ocaml-5.4-no-flat-float-array AS runner
 
-ENV PATH="/home/opam/.opam/5.1/bin:${PATH}"
+ENV PATH="/home/opam/.opam/5.4/bin:${PATH}"
 
 RUN opam update
 RUN opam install base dune ounit2 ppx_deriving ppx_sexp_conv qcheck react calendar

--- a/tests/example-empty-file/expected_results.json
+++ b/tests/example-empty-file/expected_results.json
@@ -1,6 +1,6 @@
 {
   "version": 3,
   "status": "error",
-  "message": "File \"leap.ml\", line 1:\nError: The implementation leap.ml\n       does not match the interface .test.eobjs/byte/leap.cmi: \n       The value `leap_year' is required but not provided\n       File \"leap.mli\", line 1, characters 0-26: Expected declaration\nmake: *** [Makefile:4: test] Error 1",
+  "message": "File \"leap.ml\", line 1:\nError: The implementation leap.ml does not match the interface leap.mli: \n       The value leap_year is required but not provided\n       File \"leap.mli\", line 1, characters 0-26: Expected declaration\nmake: *** [Makefile:4: test] Error 1",
   "tests": null
 }


### PR DESCRIPTION
- This updates the test runner image to OCaml 5.4.
- According to Docker hub, the previous Alpine 3.18 image has not been updated in over 2 years. With the previous base image, OPAM could only get v0.16.3 of Base even though v0.17.3 was available.
- Change to a "no flat float array" image which is a smaller image. This disables OCaml's optimizations for using float arrays, but does not prevent it from being used. It is believed the track does not make much use of float arrays.
- Also, switched to Debian 13 as the base image for Debian 13 is smaller than Alpine 3.22. Docker Hub shows the [Debian 13](https://hub.docker.com/layers/ocaml/opam/debian-ocaml-5.4-no-flat-float-array/images/sha256-4f11e70ac23af951b714b03cb36ddc7306705c508b785a7176ba7eda36c597a2) image as 617.49 MB and the [Alpine 3.22](https://hub.docker.com/layers/ocaml/opam/alpine-3.22-ocaml-5.4-no-flat-float-array/images/sha256-736010285cd96cb4520f68335f88e4022d5888a97328d176ae6fd4e1d2602b95) as 676.29 MB.

This is also for https://forum.exercism.org/t/ocaml-tests-failing-with-segfault-on-site-but-pass-locally/19744/9